### PR TITLE
update msgpackrpc Python module

### DIFF
--- a/PythonClient/cosysairsim/client.py
+++ b/PythonClient/cosysairsim/client.py
@@ -1,7 +1,6 @@
-from __future__ import print_function
 from .utils import *
 from .types import *
-import msgpackrpc  # install as admin: pip install msgpack-rpc-python
+import msgpackrpc  # install as admin: pip install rpc-msgpack
 import logging
 
 
@@ -9,8 +8,12 @@ class VehicleClient:
     def __init__(self, ip="", port=41451, timeout_value=3600):
         if ip == "":
             ip = "127.0.0.1"
-        self.client = msgpackrpc.Client(msgpackrpc.Address(ip, port), timeout=timeout_value, pack_encoding='utf-8',
-                                        unpack_encoding='utf-8')
+        self.client = msgpackrpc.Client(
+            msgpackrpc.Address(ip, port),
+            timeout=timeout_value,
+            pack_encoding='utf-8',
+            unpack_encoding='utf-8',
+        )
 
     #----------------------------------- Common vehicle APIs ---------------------------------------------
     def reset(self):

--- a/PythonClient/cosysairsim/types.py
+++ b/PythonClient/cosysairsim/types.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import numpy as np
 import math
 

--- a/PythonClient/pyproject.toml
+++ b/PythonClient/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 keywords = ["simulation", "airsim", "api"]
 dependencies = [
     "numpy",
-    "msgpack-rpc-python"
+    "rpc-msgpack"
 ]
 requires-python = ">=3.7"
 

--- a/PythonClient/requirements.txt
+++ b/PythonClient/requirements.txt
@@ -1,3 +1,3 @@
-msgpack-rpc-python
+rpc-msgpack
 numpy
 opencv-contrib-python


### PR DESCRIPTION
The original `msgpack-rpc-python` library is very old and hasn't been updated in years.

This is causing problems on newer Python versions... well anything newer than 3.5 so not that new ;-)

For example having to install backports as described in #45 

Also removed some useless import functions, as the code is not compatible with python 2 anyway.