### PR TITLE
Request for adding shell scripts for building ROS2 packages more easily.

### DIFF
--- a/docker/build_ros2.sh
+++ b/docker/build_ros2.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+SCRIPT_DIR=$(dirname "$0")
+REPO_DIR=$(dirname "${SCRIPT_DIR}")
+
+# SELECT ROS VERSION
+ROS_DISTRO=humble
+
+# RUN BUILD
+docker run -it --rm \
+	-v ${REPO_DIR}:/Cosys-AirSim \
+	--name airsim-ros2-builder \
+	-e ROS_DISTRO=${ROS_DISTRO} \
+    --workdir /Cosys-AirSim \
+	althack/ros2:${ROS_DISTRO}-base \
+    /Cosys-AirSim/docker/build_ros2_entrypoint.sh
+
+# ONLY RUN CHOWN ON EXIT CODE 0
+if [ $? -eq 0 ]; then
+	echo "Build Success. Lastly, the script will chown the repo directory to the current user."
+    sudo chown -R $(whoami):$(whoami) ${REPO_DIR}
+else
+    echo "Build Failed, Check the build statement for more information"
+fi

--- a/docker/build_ros2_entrypoint.sh
+++ b/docker/build_ros2_entrypoint.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+SCRIPT_DIR=$(dirname "$0")
+REPO_DIR=$(dirname "${SCRIPT_DIR}")
+
+echo "Selected ROS_DISTRO: ${ROS_DISTRO}"
+echo "Installing dependencies for Cosys-AirSim"
+
+$(cd ${REPO_DIR} && ./setup.sh)
+
+echo "Installing dependencies for airsim_ros_pkgs"
+
+apt install -y --no-install-recommends \
+    libyaml-cpp-dev \
+    python3-colcon-common-extensions \
+    ros-${ROS_DISTRO}-cv-bridge \
+    ros-${ROS_DISTRO}-geographic-msgs \
+    ros-${ROS_DISTRO}-image-transport \
+    ros-${ROS_DISTRO}-mavros-msgs \
+    ros-${ROS_DISTRO}-pcl-conversions
+
+echo "Building airsim_ros_pkgs"
+
+colcon --log-base ${REPO_DIR}/ros2/log \
+    build \
+    --base-paths ${REPO_DIR}/ros2 \
+    --build-base ${REPO_DIR}/ros2/build \
+    --install-base ${REPO_DIR}/ros2/install
+
+echo "Build Finished"
+
+exit 0


### PR DESCRIPTION
Hello, I appreciate your work of improving AirSim for newer environments. I benefit from your work and would like to suggest a small contribution for ease of use for using Cosys-AirSim with ROS2.

Currently, Cosys-AirSim requires user to build their own ROS2 package prior to its use. Although this is not a challenging work anymore thanks to Linux containers, I think we still need a convenience script for automatically building ROS2 packages for the Cosys-AirSim. 

This PR is consisted of two shell scripts for building a ROS2 package using [althack/ros2](https://hub.docker.com/r/althack/ros2):humble-base Docker container image. With minimal docker image and minimal ROS2 package requirements, user can simply build a ROS2 package by just `./docker/build_ros2.sh`. I think this can be also useful for configuring CI/CD for ROS2 packages.

I put these scripts in `docker` directory since I could not decide which directory would be best to fit in. Please review this suggestion and let me know if you have any recommendations for this PR. Thank you in advance.