### PR TITLE
Add simListSceneObjectsTags

### DIFF
--- a/AirLib/include/api/RpcLibClientBase.hpp
+++ b/AirLib/include/api/RpcLibClientBase.hpp
@@ -60,6 +60,7 @@ namespace airlib
         void simSetWeatherParameter(WorldSimApiBase::WeatherParameter param, float val);
 
         vector<string> simListSceneObjects(const string& name_regex = string(".*")) const;
+        vector<std::pair<string, string>> simListSceneObjectsTags(const string& name_regex = string(".*")) const;
         vector<string> simListInstanceSegmentationObjects() const;
         vector<Vector3r> simGetInstanceSegmentationColorMap() const;
         vector<Pose> simListInstanceSegmentationPoses(bool ned = true, bool only_visible = false) const;

--- a/AirLib/include/api/WorldSimApiBase.hpp
+++ b/AirLib/include/api/WorldSimApiBase.hpp
@@ -80,6 +80,7 @@ namespace airlib
         virtual void simPlotTransformsWithNames(const vector<Pose>& poses, const vector<std::string>& names, float tf_scale, float tf_thickness, float text_scale, const vector<float>& text_color_rgba, float duration) = 0;
 
         virtual std::vector<std::string> listSceneObjects(const std::string& name_regex) const = 0;
+        virtual std::vector<std::pair<std::string, std::string>> listSceneObjectsTags(const std::string& name_regex) const = 0;
         virtual std::vector<std::string> listInstanceSegmentationObjects() const = 0;
         virtual std::vector<Vector3r> getInstanceSegmentationColorMap() const = 0;
         virtual std::vector<Pose> listInstanceSegmentationPoses(bool ned = true, bool only_visible = false) const = 0;

--- a/AirLib/src/api/RpcLibClientBase.cpp
+++ b/AirLib/src/api/RpcLibClientBase.cpp
@@ -565,6 +565,11 @@ __pragma(warning(disable : 4239))
             return pimpl_->client.call("simListSceneObjects", name_regex).as<vector<string>>();
         }
 
+        vector<std::pair<string, string> > RpcLibClientBase::simListSceneObjectsTags(const string& name_regex) const
+        {
+            return pimpl_->client.call("simListSceneObjectsTags", name_regex).as<vector<std::pair<string, string>>>();
+        }
+
         vector<string> RpcLibClientBase::simListInstanceSegmentationObjects() const
         {
             return pimpl_->client.call("simListInstanceSegmentationObjects").as<vector<string>>();

--- a/AirLib/src/api/RpcLibServerBase.cpp
+++ b/AirLib/src/api/RpcLibServerBase.cpp
@@ -424,6 +424,10 @@ namespace airlib
             return getWorldSimApi()->listSceneObjects(name_regex);
         });
 
+        pimpl_->server.bind("simListSceneObjectsTags", [&](const std::string& name_regex) -> std::vector<std::pair<std::string, std::string>> {
+            return getWorldSimApi()->listSceneObjectsTags(name_regex);
+        });
+
         pimpl_->server.bind("simLoadLevel", [&](const std::string& level_name) -> bool {
             return getWorldSimApi()->loadLevel(level_name);
         });

--- a/PythonClient/cosysairsim/client.py
+++ b/PythonClient/cosysairsim/client.py
@@ -723,6 +723,21 @@ class VehicleClient:
         """
         return self.client.call('simListSceneObjects', name_regex)
 
+    def simListSceneObjectsTags(self, name_regex='.*'):
+        """
+        Lists the objects present and the given tag matching the regular expression in the environment.
+
+        The default behavior is to list all objects with first tag. A regex can be used to return a smaller list
+        of matching objects or actors.
+
+        Args:
+            name_regex (str, optional): String to match actor tags against, e.g., "Gate.*".
+
+        Returns:
+            list[list[str, str]]: List containing the names of the objects.
+        """
+        return self.client.call('simListSceneObjectsTags', name_regex)
+
     def simLoadLevel(self, level_name):
         """
         Loads a level specified by its name.

--- a/Unreal/Plugins/AirSim/Source/AirBlueprintLib.cpp
+++ b/Unreal/Plugins/AirSim/Source/AirBlueprintLib.cpp
@@ -620,6 +620,30 @@ std::vector<std::string> UAirBlueprintLib::ListMatchingActorsOriginal(const UObj
     return results;
 }
 
+std::vector<std::pair<std::string, std::string>> UAirBlueprintLib::ListMatchingActorsTags(const UObject* context, const std::string& name_regex)
+{
+    std::vector<std::pair<std::string, std::string>> results;
+    auto world = context->GetWorld();
+    std::regex compiledRegex(name_regex, std::regex::optimize);
+    for (TActorIterator<AActor> actorIterator(world); actorIterator; ++actorIterator) {
+        AActor* actor = *actorIterator;
+        bool match = false;
+        auto& tags = actor->Tags;
+        for (int32 i = 0; i < tags.Num(); ++i)
+        {
+            auto name = std::string(TCHAR_TO_UTF8(*tags[i].ToString()));
+            match = std::regex_match(name, compiledRegex);
+            if (match)
+            {
+                auto actorName = std::string(TCHAR_TO_UTF8(*actor->GetName()));
+                results.push_back({actorName, name});
+                break;
+            }
+        }
+    }
+    return results;
+}
+
 std::vector<std::string> UAirBlueprintLib::ListMatchingActors(const UObject *context, const std::string& name_regex)
 {
     std::vector<std::string> results;

--- a/Unreal/Plugins/AirSim/Source/AirBlueprintLib.h
+++ b/Unreal/Plugins/AirSim/Source/AirBlueprintLib.h
@@ -78,6 +78,7 @@ public:
     }
 
     static std::vector<std::string> ListMatchingActorsOriginal(const UObject* context, const std::string& name_regex);
+    static std::vector<std::pair<std::string, std::string>> ListMatchingActorsTags(const UObject* context, const std::string& name_regex);
     static std::vector<std::string> ListMatchingActors(const UObject *context, const std::string& name_regex);
     UFUNCTION(BlueprintCallable, Category = "AirSim|LevelAPI")
     static bool loadLevel(UObject* context, const FString& level_name);

--- a/Unreal/Plugins/AirSim/Source/WorldSimApi.cpp
+++ b/Unreal/Plugins/AirSim/Source/WorldSimApi.cpp
@@ -373,6 +373,16 @@ std::vector<std::string> WorldSimApi::listSceneObjects(const std::string& name_r
     return result;
 }
 
+std::vector<std::pair<std::string, std::string>> WorldSimApi::listSceneObjectsTags(const std::string& name_regex) const
+{
+    std::vector<std::pair<std::string, std::string>> result;
+    UAirBlueprintLib::RunCommandOnGameThread([this, &name_regex, &result]() {
+        result = UAirBlueprintLib::ListMatchingActorsTags(simmode_, name_regex);
+    },
+        true);
+    return result;
+}
+
 bool WorldSimApi::runConsoleCommand(const std::string& command)
 {
     bool succeeded = false;

--- a/Unreal/Plugins/AirSim/Source/WorldSimApi.h
+++ b/Unreal/Plugins/AirSim/Source/WorldSimApi.h
@@ -9,6 +9,7 @@
 #include "AssetRegistry/AssetData.h"
 #include "Runtime/Engine/Classes/Engine/StaticMesh.h"
 #include <string>
+#include <utility>
 
 class WorldSimApi : public msr::airlib::WorldSimApiBase
 {
@@ -73,6 +74,7 @@ public:
     virtual bool setObjectMaterial(const std::string& object_name, const std::string& material_name, const int component_id = 0) override;
     virtual bool setObjectMaterialFromTexture(const std::string& object_name, const std::string& texture_path, const int component_id = 0) override;
     virtual std::vector<std::string> listSceneObjects(const std::string& name_regex) const override;
+    virtual std::vector<std::pair<std::string, std::string>> listSceneObjectsTags(const std::string& name_regex) const override;
     virtual Pose getObjectPose(const std::string& object_name, bool ned = true) const override;
     virtual bool setObjectPose(const std::string& object_name, const Pose& pose, bool teleport) override;
     virtual bool runConsoleCommand(const std::string& command) override;

--- a/ros2/src/airsim_interfaces/CMakeLists.txt
+++ b/ros2/src/airsim_interfaces/CMakeLists.txt
@@ -37,7 +37,8 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "srv/Reset.srv"
   "srv/RefreshInstanceSegmentation.srv"
   "srv/RefreshObjectTransforms.srv"
-  "srv/SetLocalPosition.srv" DEPENDENCIES std_msgs geometry_msgs geographic_msgs LIBRARY_NAME ${PROJECT_NAME}
+  "srv/SetLocalPosition.srv"
+  "srv/ListSceneObjectTags.srv" DEPENDENCIES std_msgs geometry_msgs geographic_msgs LIBRARY_NAME ${PROJECT_NAME}
 )
 
 ament_export_dependencies(rosidl_default_runtime)

--- a/ros2/src/airsim_interfaces/srv/ListSceneObjectTags.srv
+++ b/ros2/src/airsim_interfaces/srv/ListSceneObjectTags.srv
@@ -1,0 +1,4 @@
+string regex_name
+---
+string[] objects
+string[] tags

--- a/ros2/src/airsim_ros_pkgs/include/airsim_ros_wrapper.h
+++ b/ros2/src/airsim_ros_pkgs/include/airsim_ros_wrapper.h
@@ -28,6 +28,7 @@ STRICT_MODE_OFF //todo what does this do?
 #include <airsim_interfaces/srv/takeoff_group.hpp>
 #include <airsim_interfaces/srv/refresh_instance_segmentation.hpp>
 #include <airsim_interfaces/srv/refresh_object_transforms.hpp>
+#include <airsim_interfaces/srv/list_scene_object_tags.hpp>
 #include <airsim_interfaces/msg/vel_cmd.hpp>
 #include <airsim_interfaces/msg/vel_cmd_group.hpp>
 #include <airsim_interfaces/msg/car_controls.hpp>
@@ -295,6 +296,7 @@ private:
     bool reset_srv_cb(const std::shared_ptr<airsim_interfaces::srv::Reset::Request> request, const std::shared_ptr<airsim_interfaces::srv::Reset::Response> response);
     bool instance_segmentation_refresh_cb(const std::shared_ptr<airsim_interfaces::srv::RefreshInstanceSegmentation::Request> request, const std::shared_ptr<airsim_interfaces::srv::RefreshInstanceSegmentation::Response> response);
     bool object_transforms_refresh_cb(const std::shared_ptr<airsim_interfaces::srv::RefreshObjectTransforms::Request> request, const std::shared_ptr<airsim_interfaces::srv::RefreshObjectTransforms::Response> response);
+    bool list_scene_object_tags_srv_cb(const std::shared_ptr<airsim_interfaces::srv::ListSceneObjectTags::Request> request, const std::shared_ptr<airsim_interfaces::srv::ListSceneObjectTags::Response> response);
 
     /// ROS tf broadcasters
     void publish_odom_tf(const nav_msgs::msg::Odometry& odom_msg);
@@ -384,6 +386,7 @@ private:
     rclcpp::Publisher<airsim_interfaces::msg::GPSYaw>::SharedPtr origin_geo_point_pub_; // home geo coord of drones
     msr::airlib::GeoPoint origin_geo_point_; // gps coord of unreal origin
     airsim_interfaces::msg::GPSYaw origin_geo_point_msg_; // todo duplicate
+    rclcpp::Service<airsim_interfaces::srv::ListSceneObjectTags>::SharedPtr list_scene_object_tags_srvr_;
 
     AirSimSettingsParser airsim_settings_parser_;
     std::unordered_map<std::string, std::unique_ptr<VehicleROS>> vehicle_name_ptr_map_;


### PR DESCRIPTION
I could not rename Object in 5.4 so I created list scene object filter by tags.
Tag can be attached for object and with this filter you can found group of object.
I personally use it for searching gate object, where I need to go through with vehicle.
One object can have multiple tags and filter can found first match by regex.