### PR TITLE
setup.sh: install llvm, not the llvm@8 Homebrew removed

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -29,7 +29,7 @@ done
 if [ "$(uname)" == "Darwin" ]; then # osx
     brew update
     # Update below line for newer versions
-    brew install llvm@8
+    brew install llvm
 fi
 
 if ! which cmake; then


### PR DESCRIPTION
`brew install llvm@8` fails on any current Homebrew — the oldest formula still available is `llvm@14` — so `setup.sh` cannot complete on macOS at all.

The line's own comment already says *"Update below line for newer versions"*, and `build.sh` does not want a pinned version either. Its macOS branch resolves the compiler as:

```sh
export CC="$(brew --prefix)/opt/llvm/bin/clang"
```

with the comment *"now pick up whatever setup.sh installs"*, having commented out the old `llvm@8` path. Plain `llvm` is what the rest of the build already expects.

Verified on macOS 15.7.7 / Apple M1 Pro: `setup.sh` completes, and `build.sh` then produces native arm64 `libAirLib.a`, `librpc.a` and `libMavLinkCom.a` in 1m43s.