### PR TITLE
SimJoyStick: a no-op backend for platforms with no joystick support (fixes the macOS plugin build)

### DIFF
--- a/Unreal/Plugins/AirSim/Source/SimJoyStick/SimJoyStick.cpp
+++ b/Unreal/Plugins/AirSim/Source/SimJoyStick/SimJoyStick.cpp
@@ -535,6 +535,46 @@ private:
     std::map<uint16_t, input_absinfo> absinfo_map;
 };
 
+#else // macOS and anything else without a joystick backend
+
+// AirSim's pimpl is defined only for Windows (DirectInput) and Linux (evdev).
+// On macOS neither branch is taken, so `SimJoyStick::impl` stayed an INCOMPLETE
+// TYPE while the constructor below still did `new impl()` -- five compile errors,
+// the last of them `sizeof` on an incomplete type inside unique_ptr.
+//
+// A no-op backend is the honest implementation, not a workaround: there is no
+// joystick support on this platform, and the caller's contract already covers
+// that case. `is_initialized = false` is what every consumer checks, so a
+// simulator on macOS behaves as though no stick is plugged in rather than
+// pretending one is present and reporting centred axes forever.
+struct SimJoyStick::impl
+{
+public:
+    void getJoyStickState(int index, SimJoyStick::State& state, const AxisMaps& maps)
+    {
+        unused(index);
+        unused(maps);
+        state.is_initialized = false;
+        state.is_valid = false;
+    }
+
+    void setAutoCenter(int index, double strength)
+    {
+        unused(index);
+        unused(strength);
+    }
+
+    void setWheelRumble(int index, double strength)
+    {
+        unused(index);
+        unused(strength);
+    }
+
+private:
+    template <typename T>
+    static void unused(const T&) {}
+};
+
 #endif
 
 SimJoyStick::SimJoyStick()


### PR DESCRIPTION
`SimJoyStick.cpp` is `#if _WIN32 || _WIN64 … #elif __linux__ … #endif` with **no `#else`**. On macOS neither branch is taken, so `SimJoyStick::impl` is never defined — while the constructor below the `#endif` still does `new impl()`.

That is five compile errors, ending in `sizeof` applied to an incomplete type inside `unique_ptr`, and it stops the AirSim plugin building for Unreal on macOS.

**Why a no-op backend rather than `#error`:** there is genuinely no joystick support on this platform, and the caller's contract already covers that case. Every consumer checks `state.is_initialized`, so reporting `false` makes a simulator behave as though no stick is plugged in — which is true — instead of pretending one is present and reporting centred axes forever.

I'd understand if you'd rather have `#error` or a real HID backend here; happy to change it. That is also why this is a separate PR from the other two, which are less debatable.

With this, the AirSim plugin builds against **Unreal Engine 5.8 on Apple Silicon with zero errors** (Xcode 26.1.1, macOS 15.7.7), and a SimpleFlight multirotor arms, takes off and flies to a commanded waypoint under physics.