### PR TITLE
Fix simSpawnObject argument count in the C++ client

### DIFF
--- a/AirLib/src/api/RpcLibClientBase.cpp
+++ b/AirLib/src/api/RpcLibClientBase.cpp
@@ -630,7 +630,7 @@ __pragma(warning(disable : 4239))
         std::string RpcLibClientBase::simSpawnObject(const std::string& object_name, const std::string& load_component, const Pose& pose,
                                                      const Vector3r& scale, bool physics_enabled)
         {
-            return pimpl_->client.call("simSpawnObject", object_name, load_component, RpcLibAdaptorsBase::Pose(pose), RpcLibAdaptorsBase::Vector3r(scale), physics_enabled).as<std::string>();
+            return pimpl_->client.call("simSpawnObject", object_name, load_component, RpcLibAdaptorsBase::Pose(pose), RpcLibAdaptorsBase::Vector3r(scale), physics_enabled, false).as<std::string>();
         }
 
         bool RpcLibClientBase::simDestroyObject(const std::string& object_name)

--- a/Unreal/Plugins/AirSim/Source/SimJoyStick/SimJoyStick.cpp
+++ b/Unreal/Plugins/AirSim/Source/SimJoyStick/SimJoyStick.cpp
@@ -535,46 +535,6 @@ private:
     std::map<uint16_t, input_absinfo> absinfo_map;
 };
 
-#else // macOS and anything else without a joystick backend
-
-// AirSim's pimpl is defined only for Windows (DirectInput) and Linux (evdev).
-// On macOS neither branch is taken, so `SimJoyStick::impl` stayed an INCOMPLETE
-// TYPE while the constructor below still did `new impl()` -- five compile errors,
-// the last of them `sizeof` on an incomplete type inside unique_ptr.
-//
-// A no-op backend is the honest implementation, not a workaround: there is no
-// joystick support on this platform, and the caller's contract already covers
-// that case. `is_initialized = false` is what every consumer checks, so a
-// simulator on macOS behaves as though no stick is plugged in rather than
-// pretending one is present and reporting centred axes forever.
-struct SimJoyStick::impl
-{
-public:
-    void getJoyStickState(int index, SimJoyStick::State& state, const AxisMaps& maps)
-    {
-        unused(index);
-        unused(maps);
-        state.is_initialized = false;
-        state.is_valid = false;
-    }
-
-    void setAutoCenter(int index, double strength)
-    {
-        unused(index);
-        unused(strength);
-    }
-
-    void setWheelRumble(int index, double strength)
-    {
-        unused(index);
-        unused(strength);
-    }
-
-private:
-    template <typename T>
-    static void unused(const T&) {}
-};
-
 #endif
 
 SimJoyStick::SimJoyStick()

--- a/Unreal/Plugins/AirSim/Source/SimJoyStick/SimJoyStick.cpp
+++ b/Unreal/Plugins/AirSim/Source/SimJoyStick/SimJoyStick.cpp
@@ -535,6 +535,46 @@ private:
     std::map<uint16_t, input_absinfo> absinfo_map;
 };
 
+#else // macOS and anything else without a joystick backend
+
+// AirSim's pimpl is defined only for Windows (DirectInput) and Linux (evdev).
+// On macOS neither branch is taken, so `SimJoyStick::impl` stayed an INCOMPLETE
+// TYPE while the constructor below still did `new impl()` -- five compile errors,
+// the last of them `sizeof` on an incomplete type inside unique_ptr.
+//
+// A no-op backend is the honest implementation, not a workaround: there is no
+// joystick support on this platform, and the caller's contract already covers
+// that case. `is_initialized = false` is what every consumer checks, so a
+// simulator on macOS behaves as though no stick is plugged in rather than
+// pretending one is present and reporting centred axes forever.
+struct SimJoyStick::impl
+{
+public:
+    void getJoyStickState(int index, SimJoyStick::State& state, const AxisMaps& maps)
+    {
+        unused(index);
+        unused(maps);
+        state.is_initialized = false;
+        state.is_valid = false;
+    }
+
+    void setAutoCenter(int index, double strength)
+    {
+        unused(index);
+        unused(strength);
+    }
+
+    void setWheelRumble(int index, double strength)
+    {
+        unused(index);
+        unused(strength);
+    }
+
+private:
+    template <typename T>
+    static void unused(const T&) {}
+};
+
 #endif
 
 SimJoyStick::SimJoyStick()


### PR DESCRIPTION
Fix simSpawnObject argument count in the C++ client

The C++ client sends five arguments, the server binds six, so every
simSpawnObject call from C++ fails on arity. It comes back as a generic
RPC error that says nothing about the cause, which makes it a slow one
to track down.

    RpcLibServerBase.cpp:451   ..., scale, physics_enabled, is_blueprint
    RpcLibClientBase.cpp:633   ..., scale, physics_enabled

The Python client already passes all six (PythonClient/cosysairsim/client.py:779),
so this is just the C++ side being out of step. Looks like it goes back
to 19a70097, which added is_blueprint to the server and the Python
client but not here.

Passing false, matching the Python default. Left the C++ signature
alone to keep this to the bug; exposing is_blueprint there would be a
separate change.

Tested against Blocks on UE 5.8.2, Linux: before, every spawn from the
C++ client threw; after, actors spawn and keep the name they were asked
for. simDestroyObject removes them again.
